### PR TITLE
Fix failure in python 3

### DIFF
--- a/scripts/processors/Lexicon.py
+++ b/scripts/processors/Lexicon.py
@@ -527,7 +527,7 @@ class Lexicon(SUtteranceProcessor):
             pronun = subprocess.check_output(comm.encode('utf-8'), shell=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             print(str(e.returncode) + "\n")
-            print(e.output.encode('utf-8'))
+            print(e.output)
             return None
 
         if b'failed to convert' in pronun:


### PR DESCRIPTION
Python 3 already assumes it's unicode so doesn't need to specify it again